### PR TITLE
RISC-V: Fix 'builtin-rvp32-smmul.c' testcase.

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/rvp32/builtin-rvp32-smmul.c
+++ b/gcc/testsuite/gcc.target/riscv/rvp32/builtin-rvp32-smmul.c
@@ -1,6 +1,6 @@
 /* This is a test program for smmul instruction.  */
 /* { dg-do compile { target riscv32*-*-* } } */
-/* { dg-options "-march=rv32gc_zpn -mabi=ilp32d -O3" } */
+/* { dg-options "-march=rv32iafdc_zpn -mabi=ilp32d -O3" } */
 /* { dg-final { check-function-bodies "**" "" "" } } */
 
 #include <rvp_intrinsic.h>


### PR DESCRIPTION
The patch fixes the error that the original test used '-march=rv32gc_zpn', which includes the 'M' extension. When 'M' is present, the compiler prefers the standard mulh instruction for 32-bit signed-high multiply and emits it instead of the zpn smmul instruction.