### PR TITLE
RISC-V: Fix __builtin_round NaN handling; testsuite: fix pr121510.c

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr121510.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr121510.c
@@ -8,7 +8,7 @@ void print_bfloat() {
     long j;
     union {
       _Float16 x;
-      char b[]
+      char b[];
     } u;
     j = 0;
     for (; j < sizeof 0; j++)

--- a/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c
@@ -54,5 +54,5 @@ DEF_OP_V (nearbyint, 512, double, __builtin_nearbyint)
 /* { dg-final { scan-tree-dump-not "4096,4096" "optimized" } } */
 /* { dg-final { scan-assembler-times {vfcvt\.x\.f\.v\s+v[0-9]+,\s*v[0-9]+,\s*v0\.t} 30 } } */
 /* { dg-final { scan-assembler-times {vfcvt\.f\.x\.v\s+v[0-9]+,\s*v[0-9]+,\s*v0\.t} 30 } } */
-/* { dg-final { scan-assembler-times {frflags\s+[atx][0-9]+} 32 } } */
-/* { dg-final { scan-assembler-times {fsflags\s+[atx][0-9]+} 32 } } */
+/* { dg-final { scan-assembler-times {frflags\s+[atx][0-9]+} 30 } } */
+/* { dg-final { scan-assembler-times {fsflags\s+[atx][0-9]+} 30 } } */


### PR DESCRIPTION
本 PR 包含两处相互独立的修复：

1）后端功能修复：__builtin_round 的 NaN 处理

修复 RISC-V 在 __builtin_round 遇到 NaN 时的行为问题，对应 PR：target/121652。

该修复来自/提交 1a0802e848f（[PATCH v2] RISC-V: fix __builtin_round NaN handling [PR target/121652]）。

2）testsuite 用例修复：pr121510.c 缺失分号

修复 gcc.target/riscv/rvv/autovec/pr121510.c 中 char b[] 缺失分号导致的 warning。

该 warning 会被 DejaGNU 视为未预期输出，从而触发 (test for excess errors) 导致 FAIL。

## Summary by Sourcery

Fix RISC-V __builtin_round behavior for NaN inputs and adjust related RISC-V vector tests.

Bug Fixes:
- Correct RISC-V __builtin_round expansion to properly handle NaN inputs under trapping and non-trapping math.
- Fix a missing semicolon in gcc.target/riscv/rvv/autovec/pr121510.c that caused unexpected warning output in the testsuite.

Tests:
- Update RISC-V RVV nearbyint autovec test expectations for frflags/fsflags instruction counts to match the new code generation.